### PR TITLE
Add support for python 3

### DIFF
--- a/chunkator/__init__.py
+++ b/chunkator/__init__.py
@@ -1,6 +1,7 @@
 """
 Toolbox for chunking / slicing querysets
 """
+
 from django.db.models.query import ValuesQuerySet
 
 
@@ -33,7 +34,7 @@ def chunkator(source_qs, chunk_size, query_log=None):
             queryset = source_qs.filter(pk__gt=pk)
         page = queryset[:chunk_size]
         if query_log is not None:
-            query_log.write(unicode(page.query) + "\n")
+            query_log.write('{page.query}\n'.format(page=page))
         nb_items = 0
         for item in page:
             if isinstance(queryset, ValuesQuerySet):

--- a/demo/demo_chunkator/tests.py
+++ b/demo/demo_chunkator/tests.py
@@ -1,4 +1,4 @@
-import cStringIO
+import six
 
 from django.test import TestCase
 from chunkator import chunkator, MissingPkFieldException
@@ -124,7 +124,7 @@ class ChunkatorWhereTest(TestCase):
         User.objects.create(name='ChuckNorris')
 
     def test_query_log(self):
-        query_log_output = cStringIO.StringIO()
+        query_log_output = six.StringIO()
         qs = User.objects.all()
         # We loop here only to dig into the generator and force execution
         for item in chunkator(qs, 1, query_log_output):

--- a/demo/demo_chunkator/tests.py
+++ b/demo/demo_chunkator/tests.py
@@ -113,7 +113,7 @@ class ChunkatorValuesTestCase(TestCase):
     def test_chunk_missing_pk(self):
         with self.assertRaises(MissingPkFieldException):
             result = chunkator(User.objects.all().values("name"), 10)
-            result.next()
+            six.next(result)
 
 
 class ChunkatorWhereTest(TestCase):

--- a/demo/demo_chunkator/tests.py
+++ b/demo/demo_chunkator/tests.py
@@ -22,8 +22,8 @@ class ChunkatorTestCase(TestCase):
         for item in chunks:
             self.assertTrue(isinstance(item, Book))
             result.append(item.pk)
-        self.assertEquals(len(result), 20)
-        self.assertEquals(len(result), len(set(result)))  # no duplicates
+        self.assertEqual(len(result), 20)
+        self.assertEqual(len(result), len(set(result)))  # no duplicates
 
         result = []
         # larger chunks
@@ -31,8 +31,8 @@ class ChunkatorTestCase(TestCase):
         for item in chunks:
             self.assertTrue(isinstance(item, Book))
             result.append(item.pk)
-        self.assertEquals(len(result), 20)
-        self.assertEquals(len(result), len(set(result)))  # no duplicates
+        self.assertEqual(len(result), 20)
+        self.assertEqual(len(result), len(set(result)))  # no duplicates
 
         result = []
         # larger than QS chunks
@@ -40,8 +40,8 @@ class ChunkatorTestCase(TestCase):
         for item in chunks:
             self.assertTrue(isinstance(item, Book), "{}".format(item))
             result.append(item.pk)
-        self.assertEquals(len(result), 20)
-        self.assertEquals(len(result), len(set(result)))  # no duplicates
+        self.assertEqual(len(result), 20)
+        self.assertEqual(len(result), len(set(result)))  # no duplicates
 
     def test_chunks_numqueries(self):
         # Make sure we only run 2 queries
@@ -73,8 +73,8 @@ class ChunkatorOrderTestCase(TestCase):
 
     def test_order_by_default(self):
         items = list(chunkator(Book.objects.all(), 10))
-        self.assertEquals(items[0].pk, 1)
-        self.assertEquals(items[1].pk, 2)
+        self.assertEqual(items[0].pk, 1)
+        self.assertEqual(items[1].pk, 2)
 
 
 class ChunkatorUUIDTestCase(TestCase):
@@ -90,8 +90,8 @@ class ChunkatorUUIDTestCase(TestCase):
         for item in chunks:
             self.assertTrue(isinstance(item, User))
             result.append(item.pk)
-        self.assertEquals(len(result), 2)
-        self.assertEquals(len(result), len(set(result)))  # no duplicates
+        self.assertEqual(len(result), 2)
+        self.assertEqual(len(result), len(set(result)))  # no duplicates
 
 
 class ChunkatorValuesTestCase(TestCase):
@@ -107,8 +107,8 @@ class ChunkatorValuesTestCase(TestCase):
         for item in chunks:
             self.assertTrue(isinstance(item, dict))
             result.append(item['pk'])
-        self.assertEquals(len(result), 2)
-        self.assertEquals(len(result), len(set(result)))  # no duplicates
+        self.assertEqual(len(result), 2)
+        self.assertEqual(len(result), len(set(result)))  # no duplicates
 
     def test_chunk_missing_pk(self):
         with self.assertRaises(MissingPkFieldException):
@@ -132,7 +132,7 @@ class ChunkatorWhereTest(TestCase):
         contents = query_log_output.getvalue()
         query_log_output.close()
         queries = contents.split('\n')
-        self.assertEquals(len(queries), 5, queries)
+        self.assertEqual(len(queries), 5, queries)
         queries = queries[:4]  # the last one is empty string
         for query in queries:
             # Should be 0 for the first query

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ def namespace_packages(project_name):
 
 name = 'django-chunkator'
 readme = read_relative_file('README.rst')
-requirements = []
+requirements = ['six']
 entry_points = {}
 
 

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,20 @@ if __name__ == '__main__':  # ``import setup`` doesn't trigger setup().
           description="""Chunk large querysetsinto small chunks, and iterate over them without killing your RAM.""",  # noqa
           long_description=readme,
           classifiers=[
-              "Programming Language :: Python",
+              'Environment :: Web Environment',
+              'Framework :: Django',
+              'Operating System :: OS Independent',
+              'Programming Language :: Python',
+              'Programming Language :: Python :: 2',
+              'Programming Language :: Python :: 2.7',
+              'Programming Language :: Python :: 3',
+              'Programming Language :: Python :: 3.1',
+              'Programming Language :: Python :: 3.2',
+              'Programming Language :: Python :: 3.3',
+              'Programming Language :: Python :: 3.4',
+              'Programming Language :: Python :: 3.5',
+              'Topic :: Internet :: WWW/HTTP',
+              'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
               'License :: OSI Approved :: MIT License',
           ],
           keywords='',
@@ -81,4 +94,5 @@ if __name__ == '__main__':  # ``import setup`` doesn't trigger setup().
           include_package_data=True,
           zip_safe=False,
           install_requires=requirements,
-          entry_points=entry_points)
+          entry_points=entry_points,
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27-django{16,17,18},flake8
+envlist = {py27,py34}-django{16,17,18},flake8
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
## Related issues
- #6 
## ChangeLog
- Add Python3.4 to tox matrix
- Add Python versions to setup.py
- Fix issue with StringIO w/ python3
- Remove depreciated warning about assertEquals()
- Fix generator.next()
- Use format() method to write in query_log
## Screenshot

![screenshot from 2016-06-23 13 47 53](https://cloud.githubusercontent.com/assets/251655/16302181/077a6986-394a-11e6-9cab-3bef7c9aeb67.png)

:tada: 
