### PR TITLE
Drop Django 1.6 and 1.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
 language: python
 python: 2.7
 env:
-    - TOX_ENV=py27-django16
-    - TOX_ENV=py27-django17
     - TOX_ENV=py27-django18
     - TOX_ENV=py27-django19
-    - TOX_ENV=py34-django16
-    - TOX_ENV=py34-django17
     - TOX_ENV=py34-django18
     - TOX_ENV=py34-django19
     - TOX_ENV=flake8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master (unreleased)
 
-- Nothing changed yet.
+- Drop Django 1.6 and 1.7 support (#15).
 
 ## 1.0.1 (2016-08-26)
 

--- a/chunkator/__init__.py
+++ b/chunkator/__init__.py
@@ -1,19 +1,6 @@
 """
 Toolbox for chunking / slicing querysets
 """
-import warnings
-
-from distutils.version import StrictVersion
-import django
-
-if StrictVersion(django.get_version()) < StrictVersion('1.8.0'):
-    with warnings.catch_warnings():
-        # This will force the warning to be triggered.
-        warnings.simplefilter("always")
-        warnings.warn(
-            "Django 1.7 and lower versions will soon be deprecated. Please upgrade.",  # noqa
-            PendingDeprecationWarning
-        )
 
 
 class MissingPkFieldException(Exception):

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ def namespace_packages(project_name):
 
 name = 'django-chunkator'
 readme = read_relative_file('README.rst')
-requirements = ['six']
+requirements = ['six', 'django>=1.8']
 entry_points = {}
 
 
@@ -95,4 +95,4 @@ if __name__ == '__main__':  # ``import setup`` doesn't trigger setup().
           zip_safe=False,
           install_requires=requirements,
           entry_points=entry_points,
-    )
+          )

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,9 @@
 [tox]
-envlist = {py27,py34}-django{16,17,18,19},flake8
+envlist = {py27,py34}-django{18,19},flake8
 
 [testenv]
 usedevelop = True
 deps =
-    django16: Django>=1.6,<1.7
-    django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     flake8: flake8


### PR DESCRIPTION
- [x] As soon as 1.0.1 is released...
- [x] remove from `tox.ini`,
- [x] remove from `travis.yml`,
- [x] remove `DeprecationWarning` in the main module
