### PR TITLE
Release 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## master (unreleased)
+## 1.4.0 (2018-12-17)
 
 - Django 2 support
 - Drop support for Django <1.11 and Python <3.5 (we keep 2.7 still)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## master (unreleased)
+
+Nothing to see here yet.
+
 ## 1.4.0 (2018-12-17)
 
 - Django 2 support

--- a/README.rst
+++ b/README.rst
@@ -10,8 +10,8 @@ your RAM.
 
 Tested with all the combinations of:
 
-* Python: 2.7, 3.5, 3.6
-* Django: 1.11, 2, master
+* Python: 2.7, 3.5, 3.6, 3.7
+* Django: 1.11, 2, 2.1, master
 
 
 Usage

--- a/setup.py
+++ b/setup.py
@@ -58,13 +58,13 @@ def namespace_packages(project_name):
 
 name = 'django-chunkator'
 readme = read_relative_file('README.rst')
-requirements = ['six', 'django>=1.8']
+requirements = ['six', 'django>=1.11']
 entry_points = {}
 
 
 if __name__ == '__main__':  # ``import setup`` doesn't trigger setup().
     setup(name=name,
-          version='1.4.0.dev0',
+          version='1.4.0',
           description="""Chunk large QuerySets into small chunks, and iterate over them without killing your RAM.""",  # noqa
           long_description=readme,
           classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ entry_points = {}
 
 if __name__ == '__main__':  # ``import setup`` doesn't trigger setup().
     setup(name=name,
-          version='1.4.0',
+          version='1.5.0.dev0',
           description="""Chunk large QuerySets into small chunks, and iterate over them without killing your RAM.""",  # noqa
           long_description=readme,
           classifiers=[


### PR DESCRIPTION
## Changes

- Django 2 support
- Drop support for Django <1.11 and Python <3.5 (we keep 2.7 still)
- Confirm support for Django 2.1
- Add python 3.7 support

No breaking change, just the confirmation that ``django-chunkator`` works with Django up to 2.1.