### PR TITLE
Drop `six` from requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Drop Python 2 Support (#37).
 - Drop Django 1.11 support (#40).
+- Remove `six` from the requirements (#43).
 
 ## 1.5.0 (2020-02-05)
 

--- a/demo/demo_chunkator/tests.py
+++ b/demo/demo_chunkator/tests.py
@@ -1,4 +1,4 @@
-import six
+from io import StringIO
 
 from django.test import TestCase
 
@@ -146,7 +146,7 @@ class ChunkatorValuesTestCase(TestCase):
     def test_chunk_missing_pk(self):
         with self.assertRaises(MissingPkFieldException):
             result = chunkator(User.objects.all().values("name"), 10)
-            six.next(result)
+            next(result)
 
 
 class ChunkatorWhereTest(TestCase):
@@ -157,7 +157,7 @@ class ChunkatorWhereTest(TestCase):
         User.objects.create(name='ChuckNorris')
 
     def test_query_log(self):
-        query_log_output = six.StringIO()
+        query_log_output = StringIO()
         qs = User.objects.all()
         # We loop here only to dig into the generator and force execution
         for item in chunkator(qs, 1, query_log=query_log_output):

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ def namespace_packages(project_name):
 
 name = 'django-chunkator'
 readme = read_relative_file('README.rst')
-requirements = ['six', 'django']
+requirements = ['django']
 entry_points = {}
 
 


### PR DESCRIPTION
It was necessary when we had to maintain Python 2/3 compatibility.

closes #43