### PR TITLE
v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Changelog
 
-## master (unreleased)
+## 2.0.0 (2020-06-22)
 
+- Confirm support for Django 3.0 (#41).
+- Remove `six` from the requirements (#43).
 - Drop Python 2 Support (#37).
 - Drop Django 1.11 support (#40).
-- Remove `six` from the requirements (#43).
-- Confirm support for Django 3.0 (#41).
 
 ## 1.5.0 (2020-02-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## master (unreleased)
+
+Nothing here yet.
+
 ## 2.0.0 (2020-06-22)
 
 - Confirm support for Django 3.0 (#41).

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ entry_points = {}
 
 if __name__ == '__main__':  # ``import setup`` doesn't trigger setup().
     setup(name=name,
-          version='2.0.0',
+          version='2.1.0.dev0',
           description="""Chunk large QuerySets into small chunks, and iterate over them without killing your RAM.""",  # noqa
           long_description=readme,
           classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ entry_points = {}
 
 if __name__ == '__main__':  # ``import setup`` doesn't trigger setup().
     setup(name=name,
-          version='1.6.0.dev0',
+          version='2.0.0',
           description="""Chunk large QuerySets into small chunks, and iterate over them without killing your RAM.""",  # noqa
           long_description=readme,
           classifiers=[


### PR DESCRIPTION
- Confirm support for Django 3.0 (#41).
- Remove `six` from the requirements (#43).
- Drop Python 2 Support (#37).
- Drop Django 1.11 support (#40).